### PR TITLE
Add support to timeout on getClosest

### DIFF
--- a/lib/wayback.js
+++ b/lib/wayback.js
@@ -7,9 +7,9 @@ var debug = require('debug')('wayback:main'),
 
 // a simple HTTP client
 function request(url, options, callback) {
-  if ((options instanceof Function) && (callback === null)) {
-    callback = options;
-  }
+	if ((options instanceof Function) && (callback === null)) {
+		callback = options;
+	}
 
 	var debug = require('debug')('wayback:http');
 	debug('req', url);
@@ -26,14 +26,14 @@ function request(url, options, callback) {
 		}
 	});
 
-  if (options.timeout) {
-    req.setTimeout(options.timeout);
-    req.on('timeout', function(err) {
-      var error = new Error("Request timed out");
-      debug('error', error);
-      callback(error, null);
-    });
-  }
+	if (options.timeout) {
+		req.setTimeout(options.timeout);
+		req.on('timeout', function(err) {
+			var error = new Error("Request timed out");
+			debug('error', error);
+			callback(error, null);
+		});
+	}
 
 	req.on('error', function(err) {
 		debug('error', err);
@@ -44,17 +44,17 @@ function request(url, options, callback) {
 function getClosest(url, options, callback) {
 	var closestUrl = 'http://archive.org/wayback/available?url=' + encodeURIComponent(url);
 	debug('closest', url);
-  request(closestUrl, options, function(err, res) {
-    if (err) {
-      callback(err, null);
-      return;
-    }
-    if ((options instanceof Function) && (typeof callback === 'undefined')) {
-      closest.parseClosest(res, options);
-    } else {
-      closest.parseClosest(res, callback);
-    }
-  });
+	request(closestUrl, options, function(err, res) {
+		if (err) {
+			callback(err, null);
+			return;
+		}
+		if ((options instanceof Function) && (typeof callback === 'undefined')) {
+			closest.parseClosest(res, options);
+		} else {
+			closest.parseClosest(res, callback);
+		}
+	});
 }
 
 function getTimeline(url, callback) {

--- a/lib/wayback.js
+++ b/lib/wayback.js
@@ -49,7 +49,11 @@ function getClosest(url, options, callback) {
       callback(err, null);
       return;
     }
-    closest.parseClosest(res, callback);
+    if ((options instanceof Function) && (callback == null)) {
+      closest.parseClosest(res, options);
+    } else {
+      closest.parseClosest(res, callback);
+    }
   });
 }
 

--- a/lib/wayback.js
+++ b/lib/wayback.js
@@ -6,7 +6,11 @@ var debug = require('debug')('wayback:main'),
 	timemap = require('./timemap');
 
 // a simple HTTP client
-function request(url, callback) {
+function request(url, options, callback) {
+  if ((options instanceof Function) && (callback == null)) {
+    callback = options;
+  }
+
 	var debug = require('debug')('wayback:http');
 	debug('req', url);
 
@@ -22,24 +26,31 @@ function request(url, callback) {
 		}
 	});
 
+  if (options.timeout) {
+    req.setTimeout(options.timeout);
+    req.on('timeout', function(err) {
+      var error = new Error("Request timed out");
+      debug('error', error);
+      callback(error, null);
+    });
+  }
+
 	req.on('error', function(err) {
 		debug('error', err);
 		callback(err, null);
 	});
 }
 
-function getClosest(url, callback) {
+function getClosest(url, options, callback) {
 	var closestUrl = 'http://archive.org/wayback/available?url=' + encodeURIComponent(url);
 	debug('closest', url);
-
-	request(closestUrl, function(err, res) {
-		if (err) {
-			callback(err, null);
-			return;
-		}
-
-		closest.parseClosest(res, callback);
-	});
+  request(closestUrl, options, function(err, res) {
+    if (err) {
+      callback(err, null);
+      return;
+    }
+    closest.parseClosest(res, callback);
+  });
 }
 
 function getTimeline(url, callback) {

--- a/lib/wayback.js
+++ b/lib/wayback.js
@@ -49,7 +49,7 @@ function getClosest(url, options, callback) {
       callback(err, null);
       return;
     }
-    if ((options instanceof Function) && (callback === null)) {
+    if ((options instanceof Function) && (typeof callback === 'undefined')) {
       closest.parseClosest(res, options);
     } else {
       closest.parseClosest(res, callback);

--- a/lib/wayback.js
+++ b/lib/wayback.js
@@ -7,7 +7,7 @@ var debug = require('debug')('wayback:main'),
 
 // a simple HTTP client
 function request(url, options, callback) {
-  if ((options instanceof Function) && (callback == null)) {
+  if ((options instanceof Function) && (callback === null)) {
     callback = options;
   }
 
@@ -49,7 +49,7 @@ function getClosest(url, options, callback) {
       callback(err, null);
       return;
     }
-    if ((options instanceof Function) && (callback == null)) {
+    if ((options instanceof Function) && (callback === null)) {
       closest.parseClosest(res, options);
     } else {
       closest.parseClosest(res, callback);

--- a/test/wayback.js
+++ b/test/wayback.js
@@ -2,41 +2,41 @@
 'use strict';
 
 var assert = require('assert'),
-    fs = require('fs'),
-    wayback = require('../lib/wayback');
+		fs = require('fs'),
+		wayback = require('../lib/wayback');
 
 var url = 'http://automata.cc/thumb-chuck-wiimote.png';
 
 describe('wayback', function() {
-  describe('getClosest', function() {
-    it('should get the closest url on archive', function(done) {
-      wayback.getClosest(url, function(err, resp) {
-        assert.ok(err === null);
-        assert.ok(resp instanceof Object);
-        assert.equal(resp.available, true);
-        done();
-      });
-    });
-    it('should get the closest url while using options', function(done) {
-      this.timeout(6000);
-      var options = {'timeout': 5000};
-      wayback.getClosest(url, options, function(err, resp) {
-        assert.ok(err === null);
-        assert.ok(resp instanceof Object);
-        assert.equal(resp.available, true);
-        done();
-      });
-    });
-    it('should throw an error on timeout', function(done) {
-      // Force a timeout
-      this.timeout(10000);
-      var options = {'timeout': 100};
-      wayback.getClosest(url, options, function(err, resp) {
-        assert.ok(err !== null);
-        assert.ok(err instanceof Error);
-        assert.ok(resp === null);
-        done();
-      });
-    });
-  });
+	describe('getClosest', function() {
+		it('should get the closest url on archive', function(done) {
+			wayback.getClosest(url, function(err, resp) {
+				assert.ok(err === null);
+				assert.ok(resp instanceof Object);
+				assert.equal(resp.available, true);
+				done();
+			});
+		});
+		it('should get the closest url while using options', function(done) {
+			this.timeout(6000);
+			var options = {'timeout': 5000};
+			wayback.getClosest(url, options, function(err, resp) {
+				assert.ok(err === null);
+				assert.ok(resp instanceof Object);
+				assert.equal(resp.available, true);
+				done();
+			});
+		});
+		it('should throw an error on timeout', function(done) {
+			// Force a timeout
+			this.timeout(10000);
+			var options = {'timeout': 100};
+			wayback.getClosest(url, options, function(err, resp) {
+				assert.ok(err !== null);
+				assert.ok(err instanceof Error);
+				assert.ok(resp === null);
+				done();
+			});
+		});
+	});
 });

--- a/test/wayback.js
+++ b/test/wayback.js
@@ -5,17 +5,38 @@ var assert = require('assert'),
     fs = require('fs'),
     wayback = require('../lib/wayback');
 
+var url = 'http://automata.cc/thumb-chuck-wiimote.png';
+
 describe('wayback', function() {
-  it('should throw an error on timeout', function(done) {
-    // Force a timeout
-    this.timeout(10000);
-    var url = 'http://automata.cc/thumb-chuck-wiimote.png',
-        options = {'timeout': 100};
-    wayback.getClosest(url, options, function(err, resp) {
-      assert.ok(err != null);
-      assert.ok(err instanceof Error);
-      assert.ok(resp === null);
-      done();
+  describe('getClosest', function() {
+    it('should get the closest url on archive', function(done) {
+      wayback.getClosest(url, function(err, resp) {
+        assert.ok(err === null);
+        assert.ok(resp instanceof Object);
+        assert.equal(resp.available, true);
+        done();
+      });
+    });
+    it('should get the closest url while using options', function(done) {
+      this.timeout(6000);
+      var options = {'timeout': 5000};
+      wayback.getClosest(url, options, function(err, resp) {
+        assert.ok(err === null);
+        assert.ok(resp instanceof Object);
+        assert.equal(resp.available, true);
+        done();
+      });
+    });
+    it('should throw an error on timeout', function(done) {
+      // Force a timeout
+      this.timeout(10000);
+      var options = {'timeout': 100};
+      wayback.getClosest(url, options, function(err, resp) {
+        assert.ok(err != null);
+        assert.ok(err instanceof Error);
+        assert.ok(resp === null);
+        done();
+      });
     });
   });
 });

--- a/test/wayback.js
+++ b/test/wayback.js
@@ -32,7 +32,7 @@ describe('wayback', function() {
       this.timeout(10000);
       var options = {'timeout': 100};
       wayback.getClosest(url, options, function(err, resp) {
-        assert.ok(err != null);
+        assert.ok(err !== null);
         assert.ok(err instanceof Error);
         assert.ok(resp === null);
         done();

--- a/test/wayback.js
+++ b/test/wayback.js
@@ -1,0 +1,21 @@
+/*global describe, it */
+'use strict';
+
+var assert = require('assert'),
+    fs = require('fs'),
+    wayback = require('../lib/wayback');
+
+describe('wayback', function() {
+  it('should throw an error on timeout', function(done) {
+    // Force a timeout
+    this.timeout(10000);
+    var url = 'http://automata.cc/thumb-chuck-wiimote.png',
+        options = {'timeout': 100};
+    wayback.getClosest(url, options, function(err, resp) {
+      assert.ok(err != null);
+      assert.ok(err instanceof Error);
+      assert.ok(resp === null);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Maximum timeout can be defined as a `options` parameter in `getClosest url, options, callback` while keeping the original interface: `getClosest url, callback`.

Add tests for both new and original interfaces.
