### PR TITLE
fix getTimeline

### DIFF
--- a/lib/wayback.js
+++ b/lib/wayback.js
@@ -7,7 +7,7 @@ var debug = require('debug')('wayback:main'),
 
 // a simple HTTP client
 function request(url, options, callback) {
-	if ((options instanceof Function) && (callback === null)) {
+	if ((options instanceof Function) && (callback == null)) {
 		callback = options;
 	}
 


### PR DESCRIPTION
getTimeline currently fails with:

```
/Users/me/node_modules/wayback-machine/lib/wayback.js:22
                callback(null, res);
                ^

TypeError: callback is not a function
    at ClientRequest.<anonymous> (/Users/me/node_modules/wayback-machine/lib/wayback.js:22:4)
    at ClientRequest.g (events.js:286:16)
    at emitOne (events.js:96:13)
    at ClientRequest.emit (events.js:188:7)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:472:21)
 28
    at HTTPParser.parserOnHeadersComplete (_http_common.js:105:23)
    at Socket.socketOnData (_http_client.js:361:20)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:177:18)
```

```
 node -v
v6.3.1
```

callback is undefined for the request sent form getTimeline

callback == null is true when callback is null and when callback is undefined
