### PR TITLE
Fix the regular expression that parses the key value pairs

### DIFF
--- a/lib/timemap.js
+++ b/lib/timemap.js
@@ -3,7 +3,7 @@
 var debug = require('debug')('wayback:timemap'),
 	split = require('split');
 
-var parseLineRegEx = /^(\w+)="(.*)"$/;
+var parseLineRegEx = /^(\w+)="(.*)"/;
 
 function parseLine(line) {
 	// <http://web.archive.org/web/20150418105116/https://github.com/macbre>; rel="last memento"; datetime="Sat, 18 Apr 2015 10:51:16 GMT"

--- a/test/fixtures/timemap
+++ b/test/fixtures/timemap
@@ -1,5 +1,5 @@
 <http://github.com/macbre/>; rel="original",
-<http://web.archive.org/web/timemap/link/http://github.com/macbre/>; rel="self"; type="application/link-format"; from="Mon, 23 Feb 2015 00:22:07 GMT"; until="Sat, 18 Apr 2015 10:51:16 GMT",
+<http://web.archive.org/web/timemap/link/http://github.com/macbre/>; rel="self"; type="application/link-format"; from="Mon, 23 Feb 2015 00:22:07 GMT"; until="Sat, 18 Apr 2015 10:51:16 GMT">,
 <http://web.archive.org/web/http://github.com/macbre/>; rel="timegate",
 <http://web.archive.org/web/20150223002207/https://github.com/macbre>; rel="first memento"; datetime="Mon, 23 Feb 2015 00:22:07 GMT",
 <http://web.archive.org/web/20150418105116/https://github.com/macbre>; rel="last memento"; datetime="Sat, 18 Apr 2015 10:51:16 GMT"


### PR DESCRIPTION
Fixes #14 

__Changes made:__
Updated the fixtures to include the test case
Change the regular expression in `timemap.js:6`